### PR TITLE
Image syncing

### DIFF
--- a/app/code/community/Mageflow/Connect/controllers/PullController.php
+++ b/app/code/community/Mageflow/Connect/controllers/PullController.php
@@ -122,8 +122,13 @@ class Mageflow_Connect_PullController
             $typeName = str_replace('/', '_', $changesetItem->getType());
 
             $content = Mage::helper('core')->jsonDecode($changesetItem->getContent());
+            try {
+                $metaInfo = Zend_Json::decode($changesetItem->getData('meta_info'));
+            } catch (\Exception $ex) {
+                $metaInfo = [];
+            }
 
-            $processingResponse = $this->getDataProcessor($typeName)->processData($content);
+            $processingResponse = $this->getDataProcessor($typeName)->processData($content, $metaInfo);
             if ($processingResponse['status'] && $processingResponse['status'] == 'success') {
                 $changesetItem->setStatus('Applied');
             } else {

--- a/app/code/community/Mageflow/Connect/etc/config.xml
+++ b/app/code/community/Mageflow/Connect/etc/config.xml
@@ -15,7 +15,7 @@
 <config>
     <modules>
         <Mageflow_Connect>
-            <version>2.0.1</version>
+            <version>2.0.2</version>
             <name>MageFlow Connector</name>
         </Mageflow_Connect>
     </modules>

--- a/app/code/community/Mageflow/Connect/sql/mageflow_connect_setup/upgrade-2.0.1-2.0.2.php
+++ b/app/code/community/Mageflow/Connect/sql/mageflow_connect_setup/upgrade-2.0.1-2.0.2.php
@@ -1,0 +1,29 @@
+<?php
+
+$isDevMode = Mage::getIsDeveloperMode();
+Mage::setIsDeveloperMode(true);
+
+/* @var $installer Mageflow_Connect_Model_Resource_Setup */
+$installer = $this;
+
+$installer->startSetup();
+
+$connection = $installer->getConnection();
+
+$table = $installer->getTable('mageflow_connect/changeset_item');
+if ($table && $connection->isTableExists($table)) {
+    if ($connection->tableColumnExists($table, 'metainfo')) {
+        $connection->changeColumn($table, 'metainfo', 'metainfo', 'TEXT');
+    }
+}
+
+$table = $installer->getTable('mageflow_connect/changeset_item_cache');
+if ($table && $connection->isTableExists($table)) {
+    if ($connection->tableColumnExists($table, 'meta_info')) {
+        $connection->changeColumn($table, 'meta_info', 'meta_info', 'TEXT');
+    }
+}
+
+$installer->endSetup();
+
+Mage::setIsDeveloperMode($isDevMode);


### PR DESCRIPTION
This pull request adds image syncing (meaning it will transfer the actual image data, and not only the database information.)

This is done by using the 'metainfo' field of a changeset, which contains the source URL, the image data is then received with a normal HTTP request on the moment of pulling.

Because the metainfo field is a VARCHAR with length 255, I noticed issues with too long JSON strings, so I added an update script to convert these to TEXT fields.

Possible side effects: Because of the image being copied at pull-time instead of push-time, the source image might have been removed or updated. Right now the image is only synced when the source is newer or the target image does not exist yet. This means rollbacks to previous images are not possible.